### PR TITLE
V 1.3.0

### DIFF
--- a/Magrathea/Functions.php
+++ b/Magrathea/Functions.php
@@ -15,6 +15,22 @@
 ####
 #######################################################################################
 
+/**
+ * Loads database configuration for the selected environment.
+ * 	If no environment is sent, it will use the information from the default environment
+ * @param 	string 		$env	Environment to load
+ * @return 	MagratheaDatabase Instance
+ */
+function loadMagratheaEnv($env = null){
+	global $magdb;
+	if( empty($env) ){
+		$env = MagratheaConfig::Instance()->GetEnvironment();	
+	}
+	$configSection = MagratheaConfig::Instance()->GetConfigSection($env);
+	$magdb = MagratheaDatabase::Instance();
+	return $magdb->SetConnection($configSection["db_host"], $configSection["db_name"], $configSection["db_user"], $configSection["db_pass"]);
+}
+
 //.$trace[0]["file"].":".$trace[0]["line"]."\n"
 /**
  * Prints easily and beautifully

--- a/Magrathea/LOAD.php
+++ b/Magrathea/LOAD.php
@@ -8,7 +8,6 @@ include_once($path."libs/WideImage/WideImage.php");
 //require ($path."Database.php");
 require ($path."MagratheaDatabase.php");
 
-
 require ($path."Exceptions.php");
 require ($path."MagratheaConfig.php");
 require ($path."MagratheaController.php");

--- a/Magrathea/MagratheaConfig.php
+++ b/Magrathea/MagratheaConfig.php
@@ -22,6 +22,7 @@ class MagratheaConfig {
 	private $path = __DIR__;
 	private $config_file_name = "configs/magrathea.conf";
 	private $configs = null;
+	private $environment = null;
 	protected static $inst = null;
 
 	public static function Instance(){
@@ -45,9 +46,21 @@ class MagratheaConfig {
 	/**
 	* set path for config file
 	* @param string $p Path to the file
+	* @return itself
 	*/
 	public function setPath($p){
 		$this->path = $p;
+		return $this;
+	}
+
+	/**
+	* This function will change the default environment to anything that the users wants to.
+	* @param string Environment name
+	* @return itself
+	*/
+	public function SetDefaultEnvironment($env){
+		$this->environment = $env;
+		return $this;
 	}
 
 	/**
@@ -56,7 +69,10 @@ class MagratheaConfig {
 	* @return string Environment name
 	*/
 	public function GetEnvironment(){
-		return $this->GetConfig("general/use_environment");
+		if(!isset($this->environment)){
+			$this->environment = $this->GetConfig("general/use_environment");
+		}
+		return $this->environment;
 	}
 
 	/**

--- a/Magrathea/MagratheaController.php
+++ b/Magrathea/MagratheaController.php
@@ -45,8 +45,11 @@ class MagratheaController {
 	*	@param 	string 	$control 	Control to be called
 	* 	@param 	string 	$action 	Action to be called inside the control
 	*/
-	public function ForwardTo($control, $action){
-		header("Location: /".$control."/".$action);
+	public function ForwardTo($control, $action=null){
+		if( $action )
+			header("Location: /".$control."/".$action);
+		else
+			header("Location: /".$control);
 		exit;
 	}
 

--- a/Magrathea/MagratheaController.php
+++ b/Magrathea/MagratheaController.php
@@ -166,7 +166,7 @@ class MagratheaController {
 			while (false !== ($file = readdir($handle))) {
 				$filename = explode('.', $file);
 				$ext = array_pop($filename);
-				if(empty($ext)) continue;
+				if(empty($ext) || $file[0] == "_") continue;
 				if($ext == "php"){
 					include_once($modelsFolder."/".$file);
 				}

--- a/Magrathea/MagratheaDebugger.php
+++ b/Magrathea/MagratheaDebugger.php
@@ -102,19 +102,23 @@ class MagratheaDebugger {
 	* Sets a debugger type temporarily
 	* (usefull when need to check a specific operation, for example)
 	*
-	*	@param 	string 	$dType 	type to be temporarily set
+	* @param 	string 	$dType 	type to be temporarily set
+	* @return  	itself
 	*/
 	public function SetTemp($dType){
 		$this->oldDebugType = $this->debugType;
 		$this->debugType = $dType;
+		return $this;
 	}
 
 	/**
 	* After temporarily setting a debugging type, gets it back to what it was
 	*
+	* @return  	itself
 	*/
 	public function BackTemp(){
 		$this->debugType = $this->oldDebugType;
+		return $this;
 	}
 
 	/**

--- a/Magrathea/MagratheaLogger.php
+++ b/Magrathea/MagratheaLogger.php
@@ -16,8 +16,10 @@ class MagratheaLogger {
 	 * @throws  Exception If path is not writablle
 	 */
 	public static function Log($logThis, $logFile=null){
-		if( is_a($logThis, "MagratheaConfigException") )
-			die("config not properly set!");
+		if( is_a($logThis, "MagratheaConfigException") ){
+			echo "==[config not properly set!]==";
+			return;			
+		} 
 		$path = MagratheaConfig::Instance()->GetConfigFromDefault("site_path")."/../logs/";
 		if(empty($logFile)) $logFile = "log_".@date("Ym").".txt";
 		$date = @date("Y-m-d h:i:s");

--- a/Magrathea/MagratheaQuery.php
+++ b/Magrathea/MagratheaQuery.php
@@ -69,6 +69,17 @@ class MagratheaQuery{
 	}
 
 	/**
+	 * Cleans a value in order to avoid SQL injection
+	 * @param 	string 		$query 		string to be cleared
+	 * @return  string 		clean data
+	 */
+	static public function Clean($query){
+		$query = str_replace("'", "\'", $query);
+		$query = str_replace('"', '\"', $query);
+		return $query;
+	}	
+
+	/**
 	 * Creates. Just that. Just like God did.
 	 */
 	static public function Create(){
@@ -333,7 +344,7 @@ class MagratheaQuery{
 	 */
 	public function Where($whereSql, $condition="AND"){
 		if(is_array($whereSql)){
-			return $this->WhereArray($whereSql);
+			return $this->WhereArray($whereSql, $condition);
 		}
 		array_push($this->whereArr, $whereSql);
 		return $this;

--- a/Magrathea/MagratheaView.php
+++ b/Magrathea/MagratheaView.php
@@ -160,14 +160,14 @@ class MagratheaView{
 	 * @deprecated Use Javascript instead
 	 */
 	public function Javascripts(){
-		$this->Javascript();
+		$this->Javascript(false);
 	}
 	/**
 	 * Prints all the javascripts files on page
 	 * @param 		boolean 	$compression 		should the code be compressed?
 	 * @return  	string 		Include of Javascripts
 	 */
-	public function Javascript($print=true, $compression=null){
+	public function Javascript($print=false, $compression=null){
 		$compression = ($compression==null ? $this->ShouldCompressJavascript() : $compression );
 		$array_files = array_unique($this->javascript_files);
 		$jsContent = "<!--JS FILES MANAGED BY MAGRATHEA [compression: ".$compression."] -->\n";
@@ -202,7 +202,7 @@ class MagratheaView{
 				$jsContent .= "<script type='text/javascript' src='".$this->urlForAssets.($this->relativePath ? "" : "/").$file."'></script>\n"; 
 			}
 		}
-		if($print) echo $jsContent;
+		if($print) echo $jsContent; 
 		return $jsContent;
 	}
 

--- a/Magrathea/Magrathea_admin/admin_functions.php
+++ b/Magrathea/Magrathea_admin/admin_functions.php
@@ -8,7 +8,6 @@ function getAllTables($db, $allTables=true){
 			$sql = "SELECT table_name FROM information_schema.tables WHERE TABLE_SCHEMA = '".$db."' ORDER BY TABLE_NAME";
 		else 
 			$sql = "SELECT table_name FROM information_schema.tables WHERE TABLE_SCHEMA = '".$db."' AND TABLE_NAME NOT LIKE 'magrathea%' ORDER BY TABLE_NAME";
-
 		$tables = $magdb->queryAll($sql);
 		return $tables;
 	} catch (Exception $ex){

--- a/Magrathea/Magrathea_admin/admin_load.php
+++ b/Magrathea/Magrathea_admin/admin_load.php
@@ -3,12 +3,7 @@
 	if(session_id() == '')
 		session_start();
 
-  if(isset($_POST["new_config_section"])){
-    $_SESSION["config_section"] = $_POST["new_config_section"];
-  }
-  if(isset($_SESSION["config_section"])){
-  	$GLOBALS['environment'] = $_SESSION["config_section"];
-  }
+  $environment = MagratheaConfig::Instance()->GetEnvironment();
 
   require (__DIR__."/../load_vars.php");
   require ("admin_functions.php");

--- a/Magrathea/Magrathea_admin/generate_code.php
+++ b/Magrathea/Magrathea_admin/generate_code.php
@@ -51,7 +51,7 @@ require ("admin_load.php");
 
 			if( $rel["rel_type"] == "belongs_to" ) {
 				$obj_var = "\$".strtolower($rel["rel_property"]);
-				$relations_functions .= "\tpublic function Set".$rel["rel_object"]."(".$obj_var."){\n";
+				$relations_functions .= "\tpublic function Set".$rel["rel_property"]."(".$obj_var."){\n";
 				$relations_functions .= "\t\t\$this->relations[\"properties\"][\"".$rel["rel_property"]."\"] = ".$obj_var.";\n";
 				$relations_functions .= "\t\t\$this->".$rel["rel_field"]." = ".$obj_var."->GetID();\n";
 				$relations_functions .= "\t\treturn \$this;\n";
@@ -71,10 +71,11 @@ require ("admin_load.php");
 		
 		$code .= "\tpublic \$".implode(", $", $obj_fields).";\n";
 		$code .= "\tpublic \$created_at, \$updated_at;\n";
+		$code .= "\tpublic \$dbPk;\n";
 		$code .= "\tprotected \$autoload = ".(count($relations_autoload) == 0 ? "null" : "array(".implode(", ", $relations_autoload).")").";\n\n";
 		
 		$code .= "\tpublic function __construct( ".( ($data["db_pk"]) ? " \$".$data["db_pk"]."=0 " : "\$id=0" )." ){ \n";
-			$code .= "\t\t\$this->Start();\n";
+			$code .= "\t\t\$this->MagratheaStart();\n";
 			if($data["db_pk"]){
 				$code .= "\t\tif( !empty(\$".$data["db_pk"].") ){\n";
 					$code .= "\t\t\t\$pk = \$this->dbPk;\n";
@@ -83,7 +84,7 @@ require ("admin_load.php");
 				$code .= "\t\t}\n";
 			}
 		$code .= "\t}\n";
-		$code .= "\tpublic function Start(){\n";
+		$code .= "\tpublic function MagratheaStart(){\n";
 			$code .= "\t\t\$this->dbTable = \"".$data["table_name"]."\";\n";
 			$code .= "\t\t\$this->dbPk = \"".$data["db_pk"]."\";\n";
 			foreach($obj_fields as $f){

--- a/Magrathea/Magrathea_admin/load_migration.php
+++ b/Magrathea/Magrathea_admin/load_migration.php
@@ -56,9 +56,9 @@ $config = MagratheaConfig::Instance()->GetConfig();
 					?>
 					<div class="singlePlugin <?=($even ? "even" : "odd")?>">
 						<div class='row-fluid' style="padding-top: 5px;">
-							<div class="span9" style="padding-left: 20px;"><?=$obj?></div>
-							<div class="span3 right" style="padding-right: 20px;">
-								<button class="btn btn-default" onClick="databaseDetail('<?=$obj?>', this);"><i class="fa fa-database"></i> <i class="fa fa-terminal"></i>&nbsp;View query</button>
+							<div class="span6" style="padding-left: 20px;"><?=$obj?></div>
+							<div class="span6 right" style="padding-right: 20px;">
+								<button class="btn btn-default" onClick="objectDetail('<?=$obj?>', this);"><i class="fa fa-book"></i> <i class="fa fa-terminal"></i>&nbsp;Create object query</button>
 							</div>
 						</div>
 					</div>
@@ -75,11 +75,11 @@ $config = MagratheaConfig::Instance()->GetConfig();
 <script type="text/javascript">
 var responseDiv = null;
 
-function databaseDetail(obj, element){
+function objectDetail(obj, element){
 	responseIn = $("#query_run");
 	$(responseIn).html("Loading...");
 	$.ajax({
-		url: "?magpage=database_table.php",
+		url: "?magpage=object_query.php",
 		type: "POST",
 		data: { 
 			object: obj

--- a/Magrathea/Magrathea_admin/load_object.php
+++ b/Magrathea/Magrathea_admin/load_object.php
@@ -228,12 +228,17 @@ function addNewRelation(){
 	var rel_type = $("#relation_type option:selected").val();
 	var rel_type_val = $("#relation_type option:selected").val();
 	var rel_object = $("#relation_object option:selected").val();
-	var relation_name = "rel_<?=$obj_name?>_"+rel_type_val+"_"+rel_object;
-
 	var rel_field = $("#relation_field option:selected").val();
-
-	var property = (rel_type == "belongs_to" ? rel_object : rel_object+"s");
-	var method = (rel_type == "belongs_to" ? "Get"+rel_object : "Get"+rel_object+"s");
+	var relation_name, property, method;
+	if( rel_type == "has_many" ) {
+		relation_name = "rel_<?=$obj_name?>_"+rel_type_val+"_"+rel_object+"+"+rel_field;
+		property = rel_object;
+		method = "Get"+rel_object;
+	} else {
+		relation_name = "rel_<?=$obj_name?>"+"+"+rel_field+"_"+rel_type_val+"_"+rel_object;
+		property = rel_object+"s";
+		method = "Get"+rel_object+"s";
+	}
 
 	HtmlRelation(relation_name, rel_type, rel_type_val, rel_object, rel_field, method, property);
 	ShowHideNewRelation();
@@ -287,12 +292,8 @@ function DeleteRelation(rel_name){
 			relation: rel_name
 		}, 
 		success: function(data){
-			if( data == "<!--false-->" ){
-				$.jGrowl("Some error happened when trying to delete this relation!", { header: 'Error', theme:"notification_styled_error" });	
-			} else if (data == "<!--true--->") {
-				$.jGrowl("Relation was deleted", { header: 'Bye bye, relation...', theme:"notification_styled_success" });			
-				$("#"+rel_name).remove();
-			}
+			$("#object_result").html(data);
+			scrollToTop();
 		}
 	});
 }

--- a/Magrathea/Magrathea_admin/load_table.php
+++ b/Magrathea/Magrathea_admin/load_table.php
@@ -4,9 +4,9 @@ require ("admin_load.php");
 
 $table = $_POST["table"];
 $query = "SHOW columns FROM ".$table;
-$columns = $magdb->queryAll($query);
+$columns = MagratheaDatabase::Instance()->QueryAll($query);
 $query = "SHOW INDEX FROM ".$table;
-$indexes = $magdb->queryAll($query);
+$indexes = MagratheaDatabase::Instance()->QueryAll($query);
 
 //p_r($columns);
 

--- a/Magrathea/Magrathea_admin/menu.php
+++ b/Magrathea/Magrathea_admin/menu.php
@@ -2,7 +2,9 @@
 
 require_once ("admin_load.php");
 
-$tables = getAllTables(@$configSection["db_name"], false);
+$databaseName = MagratheaConfig::Instance()->GetConfigFromDefault("db_name");
+
+$tables = getAllTables($databaseName, false);
 //$allTables = getAllTables(@$configSection["db_name"], true);
 //p_r($tables);
 $objects = getAllObjects();
@@ -10,6 +12,10 @@ $objects = getAllObjects();
 ?>
 
   <ul class="nav nav-list bs-docs-sidenav menu">
+  	<li class="menu-header">
+  		Environment: <?php echo MagratheaConfig::Instance()->GetEnvironment(); ?> <br/>
+  		Database: <?php echo $databaseName; ?> 
+  	</li>
 	<li><a onClick="loadConfig();" id="menu_config"><i class="fa fa-cogs"></i> Configuration</a></li>
     <li class="submenu"><a href="#"><i class="fa fa-table"></i> Tables <span class="number"><?=count($tables)?></span></a>
     	<ul class="nav nav-list menu_sublist" style="display: none;">

--- a/Magrathea/Magrathea_admin/object_query.php
+++ b/Magrathea/Magrathea_admin/object_query.php
@@ -43,6 +43,7 @@ foreach($obj as $key => $item){
 }
 
 
+
 $createSql .= "\tPRIMARY KEY (`".$obj["db_pk"]."`)\n";
 $createSql .= "\n) DEFAULT CHARSET=utf8 ;";
 $createSql .= "\n\n";
@@ -53,23 +54,6 @@ $createSql .= "CREATE TRIGGER `".$obj["table_name"]."_create` BEFORE INSERT ON `
 $createSql .= "CREATE TRIGGER `".$obj["table_name"]."_update` BEFORE UPDATE ON `".$obj["table_name"]."` FOR EACH ROW SET NEW.updated_at = NOW();\n";
 
 $createSql .= "\n\n";
-
-
-$query = "SHOW INDEX FROM ".$obj["table_name"];
-$indexes = $magdb->queryAll($query);
-$addIndexes = array();
-foreach ($indexes as $i) {
-	if( $i["key_name"] == "PRIMARY" ) continue;
-	else if( $i["non_unique"] == 0 ) array_push($addIndexes, "ADD UNIQUE INDEX(`".$i["column_name"]."`)");
-	else if( $i["index_type"] == "FULLTEXT" ) array_push($addIndexes, "ADD FULLTEXT(`".$i["column_name"]."`)");
-	else array_push($addIndexes, "ADD INDEX(`".$i["column_name"]."`)");
-}
-if(count($addIndexes) > 0){
-	$createSql .= "ALTER TABLE `".$obj["table_name"]."`\n";
-	$createSql .= implode(",\n", $addIndexes).";";
-	$createSql .= "\n\n";
-}
-
 
 die($createSql);
 

--- a/Magrathea/Magrathea_admin/resources/css.php
+++ b/Magrathea/Magrathea_admin/resources/css.php
@@ -78,4 +78,11 @@ ul.nav-list li a i {
     margin-right: 8px;	
 }
 
+li.menu-header {
+    border: 1px solid #E5E5E5;
+    padding: 10px;
+    font-weight: bolder;
+    background-color: #E5E5E5;
+}
+
 </style>

--- a/Magrathea/Magrathea_admin/resources/javascript_admin.php
+++ b/Magrathea/Magrathea_admin/resources/javascript_admin.php
@@ -242,7 +242,7 @@ function saveConfig(specific){
 			var success_var = data.substr(0, 12);
 //			console.info(success_var);
 			$("#config_result").html(data);
-			scrollToTop();
+			window.location.reload();
 		}
 	});
 }

--- a/Magrathea/Magrathea_admin/save_object.php
+++ b/Magrathea/Magrathea_admin/save_object.php
@@ -2,7 +2,10 @@
 
 require ("admin_load.php");
 
+	/*** CAUTION: EXTREMELY COMPLICATED LOGIC ***/
+
 	$data = $_POST;
+//	p_r($data);
 	$object_name = $data["object_name"];
 	$object_data = getObject($object_name);
 	
@@ -19,17 +22,38 @@ require ("admin_load.php");
 			$type_text = $data["rel_type_text"][$i_rel_obj];
 			$object = $data["rel_object"][$i_rel_obj];
 			$field = $data["rel_field"][$i_rel_obj];
-			$rel_name = "rel_".$object_name."_".$type."_".$object;
+
+			switch($type){
+				case "has_many":
+					$rel_name = "rel_".$object_name."_".$type."_".$object."+".$field;
+				break;
+				case "belongs_to":
+				default:
+					$rel_name = "rel_".$object_name."+".$field."_".$type."_".$object;
+				break;
+			}
+
 	
 			$property = $data[$rel_name."_property"];
 			$method = $data[$rel_name."_method"];
 			$lazyload = $data[$rel_name."_lazyload"];
 			$autoload = $data[$rel_name."_autoload"];
 
-			if( empty($property) )
-				$property = ($type == "belong_to" ? $object : $object."s" );
-			if( empty($method) )
-				$method = ($type == "belong_to" ? "Get".$object : "Get".$object."s" );
+			switch($type){
+				case "has_many":
+					if( empty($property) )
+						$property = $object;
+					if( empty($method) )
+						$method = "Get".$object;
+				break;
+				case "belongs_to":
+				default:
+					if( empty($property) )
+						$property = $object."s";
+					if( empty($method) )
+						$method = "Get".$object."s";
+				break;
+			}
 
 			$rel_id = @count($relations["rel_name"]);
 			$i = 0;
@@ -60,21 +84,23 @@ require ("admin_load.php");
 					$mirror_type_text = "has many";
 					$mirror_property = $mirror_obj."s";
 					$mirror_method = "Get".$mirror_obj."s";
+					$mirror_name = "rel_".$mirror_obj_base."_".$mirror_type."_".$mirror_obj."+".$field;
 				break;
 				case "has_many":
 					$mirror_type = "belongs_to";
 					$mirror_type_text = "belongs to";
 					$mirror_property = $mirror_obj;
 					$mirror_method = "Get".$mirror_obj;
+					$mirror_name = "rel_".$mirror_obj_base."+".$field."_".$mirror_type."_".$mirror_obj;
 				break;
 				default:
 					$mirror_type = $type;
 					$mirror_type_text = $type_text;
 					$mirror_property = $mirror_obj."s";
 					$mirror_method = "Get".$mirror_obj."s";
+					$mirror_name = "rel_".$mirror_obj_base."+".$field."_".$mirror_type."_".$mirror_obj;
 				break;
 			}
-			$mirror_name = "rel_".$mirror_obj_base."_".$mirror_type."_".$mirror_obj;
 			$mirror_lazyload = 1;
 			$mirror_autoload = 0;
 
@@ -102,7 +128,6 @@ require ("admin_load.php");
 			$relations["rel_method"][$rel_id] = $mirror_method;
 			$relations["rel_lazyload"][$rel_id] = $mirror_lazyload;
 			$relations["rel_autoload"][$rel_id] = $mirror_autoload;
-	
 			$i_rel_obj++;
 		}
 	}
@@ -135,7 +160,7 @@ require ("admin_load.php");
 	}
 
 ?>
-<!--true--->
+<!--true-->
 <div class="alert alert-success">
 	<button class="close" data-dismiss="alert" type="button">×</button>
 	<strong>Yeah, baby!</strong><br/>

--- a/Magrathea/load_vars.php
+++ b/Magrathea/load_vars.php
@@ -7,14 +7,11 @@ if(isset($site_path)){
 
 $magdb = null;
 try	{
-	$configSection = MagratheaConfig::Instance()->GetConfigSection(MagratheaConfig::Instance()->GetEnvironment());
-	$magdb = MagratheaDatabase::Instance();
-	$magdb->SetConnection($configSection["db_host"], $configSection["db_name"], $configSection["db_user"], $configSection["db_pass"]);
+	loadMagratheaEnv();
 } catch (Exception $ex){
 	$error_msg = "Error: ".$ex->getMessage();
 	echo $error_msg; die;
 }
-
 
 // optional:
 date_default_timezone_set( MagratheaConfig::Instance()->GetConfig("general/time_zone") );

--- a/Magrathea/version
+++ b/Magrathea/version
@@ -1,1 +1,1 @@
-version: 1.2.2
+version: 1.3.0

--- a/README.md
+++ b/README.md
@@ -16,14 +16,29 @@ rm -rf MagratheaPHP
 
 ## changelog
 
+### version 1.3.0
+- __WARNING :__ Changed the way the relations are stored in Configuration. Now one object can have more than one relation with another object (task can be related to user from two different columns, for example). So, the way relations created in MagratheaAdmin are stored changed and MagratheaAdmin can possibliy stop working for getting already stabilished relations. - to fix, check our new manual fixes section (acccessing the folder [https://github.com/PlatypusTechnology/MagratheaPHP/tree/master/documentation/manuals](documentation/manuals) on the root of this project)
+- __NEW :__ `documentation/manuals` folder added for multiple use [https://github.com/PlatypusTechnology/MagratheaPHP/tree/master/documentation/manuals](here)
+- __FIX :__ `MagratheaLogger` does not ends application in case of `MagratheaConfigException` (yes, it was a stupid idea, now I see)
+- __NEW :__ Function `SetEnvironment`, on `MagratheaConfig`, that allows the user to dinamically change the default environment from the configuration file
+- __NEW :__ Static function `Clean`, on `MagratheaQuery`, to clean a string for a query
+- __IMPROVEMENT :__ more functions can act as decorator on `MagratheaDebugger`
+- __IMPROVEMENT :__ table query creator always adds `utf8` collation
+- __IMPROVEMENT :__ `Start()` function from models were changed to `MagratheaStart()` in order to avoid conflicts
+- __IMPROVEMENT :__ `ForwardTo($action, $control)` function from `MagratheaControl` now can work if receives only `$action`
+- __FIX + NEW :__ Magrathea Admin migrations now are based on magrathea objects, not on (considered) existing magrathea tables. This way, it gets easier to import them to a new system.
+- __FIX :__ MagratheaAdmin database and environment always coming from Config
+- __FIX :__ MagratheaAdmin deleting relation
+- __FIX :__ MagratheaAdmin code generation improved for avoid duplication for multiple lists of same object. Now the name of the functions are based on the name and alias of the object, not on the type of the object.
+- __FIX :__ start.sh fixed permissions of static folder
+- __FIX :__ `$dbPk` now public accessible in `MagratheaModels`
+
 #### version 1.2.2
 - __FIX :__ start.sh fixed
-
 #### version 1.2.1
 - __FIX :__ MagratheaAdmin => not required plugins where throwing fatal errors. This was fixed and when a not required plugin is missing, it will display a message with a link for it to be installed.
 - __FIX :__ Inifinite loop on JavaScripts include if js compression was on (js compression still does not work!)
 - __IMPROVEMENT :__ silent load for MagratheaImages: do not load javascripts
-
 ### version 1.2.0
 - __NEW :__ WideImage library is now part of Magrathea's libs and is always automatically loaded
 - __FIX :__ MagratheaDebugger doesn't flash notices anymore
@@ -43,9 +58,17 @@ rm -rf MagratheaPHP
 #### version 1.0.1
 - Static generation fixed
 - Short PHP tags support fixed
-
 ### version: 1.0
 - First stable version
 
+
+## TO DO
+- Database migrations
+- move plugins folder on directory up (due to security reasons)
+- find a way to deal better with plugin config files
+- Sass Compressor
+- Put Javascript compressor back to work
+- improve documentation
+- PHP 7.0 (on version 2.0 of Magrathea!)
 
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ rm -rf MagratheaPHP
 - __IMPROVEMENT :__ table query creator always adds `utf8` collation
 - __IMPROVEMENT :__ `Start()` function from models were changed to `MagratheaStart()` in order to avoid conflicts
 - __IMPROVEMENT :__ `ForwardTo($action, $control)` function from `MagratheaControl` now can work if receives only `$action`
+- __IMPROVEMENT :__ Controllers starting with `_` are not included in the `IncludeAllControllers` function
 - __FIX + NEW :__ Magrathea Admin migrations now are based on magrathea objects, not on (considered) existing magrathea tables. This way, it gets easier to import them to a new system.
 - __FIX :__ MagratheaAdmin database and environment always coming from Config
 - __FIX :__ MagratheaAdmin deleting relation

--- a/documentation/inc/header.php
+++ b/documentation/inc/header.php
@@ -87,6 +87,7 @@
             <li class="divider"></li>
             <li><a href="deprecated.html.php"><i class="icon-warning-sign"></i> deprecated</a></li>
             <li><a href="todo.html.php"><i class="icon-tasks"></i> todo</a></li>
+            <li><a href="https://github.com/PlatypusTechnology/MagratheaPHP/tree/master/documentation/manuals"><i class="icon-tasks"></i> Extra Manuals</a></li>
           </ul>
         </li>
         <li>

--- a/documentation/index.php
+++ b/documentation/index.php
@@ -49,7 +49,7 @@
 	</p>
 
 	<hr/>
-	<em>version: 1.1</em>
+	<em>version: 1.3.0</em>
 </div>
 
 <?php include("inc/footer.php"); ?>

--- a/documentation/manuals/1.3.0-fixing-object.md
+++ b/documentation/manuals/1.3.0-fixing-object.md
@@ -1,0 +1,69 @@
+# Magrathea Fix for v.1.3.0
+
+### change:
+The way relational information is stored was modified. Now one object can have more than one same relation with the same other object.
+Example:
+we have an object `task` and an object `user`.
+If two different columns are linking a task to a user, in previous versions of Magrathea, this relation would be always overwrited when you created a new relation using the same two objects. This was happening because the way the relations were being stored in `magrathea_objects.conf`:
+
+```
+[relations]
+	rel_name[] = "rel_User_has_many_Tasks"
+	rel_obj_base[] = "User"
+	rel_type[] = "has_many"
+	rel_type_text[] = "has many"
+	rel_object[] = "Task"
+	rel_field[] = "user_created"
+	rel_property[] = "User"
+	rel_method[] = "GetUser"
+```
+
+now, the new version would create something like this
+
+```
+[relations]
+	rel_name[] = "rel_user_created_has_many_Tasks"
+	rel_obj_base[] = "User"
+	rel_type[] = "has_many"
+	rel_type_text[] = "has many"
+	rel_object[] = "Task"
+	rel_field[] = "user_created"
+	rel_property[] = "CreateUser"
+	rel_method[] = "GetCreateUser"
+```
+
+the change was setting the column to the relation name instead of setting the object.
+so now, for creating more relations would be easy:
+
+```
+[relations]
+	rel_name[] = "rel_user_created_has_many_Tasks"
+	rel_name[] = "rel_user_assigned_has_many_Tasks"
+	rel_obj_base[] = "User"
+	rel_obj_base[] = "User"
+	rel_type[] = "has_many"
+	rel_type[] = "has_many"
+	rel_type_text[] = "has many"
+	rel_type_text[] = "has many"
+	rel_object[] = "Task"
+	rel_object[] = "Task"
+	rel_field[] = "user_created"
+	rel_field[] = "user_assigned"
+	rel_property[] = "CreateUser"
+	rel_property[] = "AssignedUser"
+	rel_method[] = "GetCreateUser"
+	rel_method[] = "GetAssignedUser"
+```
+
+
+
+for relations created before than that, however, you may lose the connection. This would happen if the name used to the property is a different name than the name of the object.
+To fix this, just manually replace the name of the object for the column of the property on the relation name.
+
+Sorry about this mess.
+
+
+Paulo Martins
+(Platypus Technology)
+
+

--- a/start.sh
+++ b/start.sh
@@ -44,6 +44,8 @@ mkdir Controls
 echo -e "\tControls = ok\n"
 
 mkdir Static
+chmod 777 Static
+touch Static/.gitkeep
 echo -e "\tStatic = ok\n"
 
 mkdir javascript
@@ -282,6 +284,7 @@ app/Views/_compiled
 app/javascript/_compressed
 app/css/_compressed
 app/plugins
+app/Static
 *_compressed.js
 *_compressed.css
 *.magratheaDB


### PR DESCRIPTION
### version 1.3.0
- **WARNING :** Changed the way the relations are stored in Configuration. Now one object can have more than one relation with another object (task can be related to user from two different columns, for example). So, the way relations created in MagratheaAdmin are stored changed and MagratheaAdmin can possibliy stop working for getting already stabilished relations. - to fix, check our new manual fixes section (acccessing the folder [https://github.com/PlatypusTechnology/MagratheaPHP/tree/master/documentation/manuals](documentation/manuals) on the root of this project)
- **NEW :** `documentation/manuals` folder added for multiple use [https://github.com/PlatypusTechnology/MagratheaPHP/tree/master/documentation/manuals](here)
- **FIX :** `MagratheaLogger` does not ends application in case of `MagratheaConfigException` (yes, it was a stupid idea, now I see)
- **NEW :** Function `SetEnvironment`, on `MagratheaConfig`, that allows the user to dinamically change the default environment from the configuration file
- **NEW :** Static function `Clean`, on `MagratheaQuery`, to clean a string for a query
- **IMPROVEMENT :** more functions can act as decorator on `MagratheaDebugger`
- **IMPROVEMENT :** table query creator always adds `utf8` collation
- **IMPROVEMENT :** `Start()` function from models were changed to `MagratheaStart()` in order to avoid conflicts
- **IMPROVEMENT :** `ForwardTo($action, $control)` function from `MagratheaControl` now can work if receives only `$action`
- **IMPROVEMENT :** Controllers starting with `_` are not included in the `IncludeAllControllers` function
- **FIX + NEW :** Magrathea Admin migrations now are based on magrathea objects, not on (considered) existing magrathea tables. This way, it gets easier to import them to a new system.
- **FIX :** MagratheaAdmin database and environment always coming from Config
- **FIX :** MagratheaAdmin deleting relation
- **FIX :** MagratheaAdmin code generation improved for avoid duplication for multiple lists of same object. Now the name of the functions are based on the name and alias of the object, not on the type of the object.
- **FIX :** start.sh fixed permissions of static folder
- **FIX :** `$dbPk` now public accessible in `MagratheaModels`
